### PR TITLE
战术动作完善

### DIFF
--- a/src/main/java/com/modularwarfare/client/handler/ClientTickHandler.java
+++ b/src/main/java/com/modularwarfare/client/handler/ClientTickHandler.java
@@ -28,6 +28,9 @@ import com.modularwarfare.utility.RayUtil;
 import com.modularwarfare.common.guns.manager.ShotManager;
 import com.modularwarfare.common.type.BaseItem;
 
+import mchhui.modularmovements.ModularMovements;
+import mchhui.modularmovements.tactical.client.ClientListener;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.EntityLivingBase;
@@ -327,25 +330,35 @@ public final class ClientTickHandler {
             if(Mouse.isButtonDown(1)) {
                 recover=0.8f;
             }
+            
+            float rollAddition = 0f;
+            if (ModularWarfare.isLoadedModularMovements) {
+                float rollProgress = ClientListener.getRollProgressInterpolated(renderTick);
+                if (rollProgress > 0) {
+                    rollAddition = (float)(gun.type.gunHoldLength * 2.0 * rollProgress);
+                }
+            }
+            
             //枪械长度计算
             if(rayTraceResult != null) {
                 if (rayTraceResult.typeOfHit == RayTraceResult.Type.BLOCK) {
                     if (rayTraceResult.hitVec != null) {
                         double d = vecStart.distanceTo(rayTraceResult.hitVec);
                         double length = gun.type.gunHoldLength;
+                        
                         if (d <= length) {
-                            RenderParameters.collideFrontDistance = (float) (RenderParameters.collideFrontDistance + ((length - d) - RenderParameters.collideFrontDistance) * renderTick * 0.5f);
+                            RenderParameters.collideFrontDistance = (float) (RenderParameters.collideFrontDistance + ((length - d + rollAddition) - RenderParameters.collideFrontDistance) * renderTick * 0.5f);
                         } else {
-                            RenderParameters.collideFrontDistance = Math.max(0f, RenderParameters.collideFrontDistance - renderTick * recover);
+                            RenderParameters.collideFrontDistance = Math.max(rollAddition, RenderParameters.collideFrontDistance - renderTick * recover);
                         }
                     } else {
-                        RenderParameters.collideFrontDistance = Math.max(0f, RenderParameters.collideFrontDistance - renderTick * recover);
+                        RenderParameters.collideFrontDistance = Math.max(rollAddition, RenderParameters.collideFrontDistance - renderTick * recover);
                     }
                 } else {
-                    RenderParameters.collideFrontDistance = Math.max(0f, RenderParameters.collideFrontDistance - renderTick * recover);
+                    RenderParameters.collideFrontDistance = Math.max(rollAddition, RenderParameters.collideFrontDistance - renderTick * recover);
                 }
             } else {
-                RenderParameters.collideFrontDistance = Math.max(0f, RenderParameters.collideFrontDistance - renderTick * recover);
+                RenderParameters.collideFrontDistance = Math.max(rollAddition, RenderParameters.collideFrontDistance - renderTick * recover);
             }
 
             /**

--- a/src/main/java/mchhui/modularmovements/ModularMovementsConfig.java
+++ b/src/main/java/mchhui/modularmovements/ModularMovementsConfig.java
@@ -14,9 +14,9 @@ public class ModularMovementsConfig {
 
     public Lean lean = new Lean();
     public Slide slide = new Slide();
-
     public Sit sit = new Sit();
     public Crawl crawl = new Crawl();
+    public Dodge dodge = new Dodge();
 
     public static class Lean {
         public boolean enable = true;
@@ -33,11 +33,22 @@ public class ModularMovementsConfig {
     public static class Sit {
         public boolean enable = true;
         public boolean autoHold = true;
+        public int cooldownMs = 300;
     }
 
     public static class Crawl {
         public boolean enable = true;
         public boolean sprintCancel = true;
+        public int cooldownMs = 500;
+    }
+    
+    public static class Dodge {
+        public boolean enable = true;
+        public int divingThresholdMs = 210;
+        public int pounceCooldownMs = 800;
+        public int pounceGroundCooldownMs = 600;
+        public int rollCooldownMs = 800;
+        public int rollSecondCooldownMs = 2200;
     }
 
     public String version = ModularMovements.MOD_VERSION;

--- a/src/main/java/mchhui/modularmovements/tactical/PlayerState.java
+++ b/src/main/java/mchhui/modularmovements/tactical/PlayerState.java
@@ -33,8 +33,21 @@ public class PlayerState {
     public long nextDivingTime;
     public long nextStepTime;
     
+    public float rollProgress = 0.0f;
+    public float prevRollProgress = 0.0f;
+    
+    public long pounceGroundTime = 0;
+    public boolean wasInAirDuringPounce = false;
+    
     public boolean isBackLying = false;
     public int rollFace;
+    
+    public boolean isRolling = false;
+    public boolean isPouncing = false;
+    public long rollEndTime = 0;
+    public long pounceEndTime = 0;
+    
+    public Float lockedRenderYaw = null;
     
     public AxisAlignedBB lastAABB;
     public AxisAlignedBB lastModAABB;
@@ -78,12 +91,14 @@ public class PlayerState {
 
     @SideOnly(Side.CLIENT)
     public boolean canSit() {
-        return ModularMovements.REMOTE_CONFIG.sit.enable && ((System.currentTimeMillis() - lastSit) > 300);
+        return ModularMovements.REMOTE_CONFIG.sit.enable && 
+               ((System.currentTimeMillis() - lastSit) > ModularMovements.REMOTE_CONFIG.sit.cooldownMs);
     }
 
     @SideOnly(Side.CLIENT)
     public boolean canCrawl() {
-        return ModularMovements.REMOTE_CONFIG.crawl.enable && ((System.currentTimeMillis() - lastCrawl) > 500);
+        return ModularMovements.REMOTE_CONFIG.crawl.enable && 
+               ((System.currentTimeMillis() - lastCrawl) > ModularMovements.REMOTE_CONFIG.crawl.cooldownMs);
     }
 
     @SideOnly(Side.CLIENT)
@@ -111,7 +126,9 @@ public class PlayerState {
 
     public void disableCrawling() {
         isCrawling = false;
-        this.lastCrawl = System.currentTimeMillis();  
+        this.lastCrawl = System.currentTimeMillis();
+        this.pounceGroundTime = 0;
+        this.wasInAirDuringPounce = false;
     }
 
     public void resetProbe() {

--- a/src/main/java/mchhui/modularmovements/tactical/client/ClientListener.java
+++ b/src/main/java/mchhui/modularmovements/tactical/client/ClientListener.java
@@ -10,6 +10,7 @@ import mchhui.modularmovements.tactical.PlayerState;
 import mchhui.modularmovements.tactical.network.AnimationHandler;
 import mchhui.modularmovements.tactical.network.TacticalHandler;
 import mchhui.modularmovements.tactical.server.ServerListener;
+import com.modularwarfare.client.input.KeyBindingUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -125,7 +126,19 @@ public class ClientListener {
             if (Minecraft.getMinecraft().player.posZ != Minecraft.getMinecraft().player.lastTickPosZ) {
                 crawlingMousePosXMove = 0;
             }
-            if (Minecraft.getMinecraft().player.isSprinting() && !clientPlayerState.isSitting) {
+            
+            boolean inPounceCooldown = false;
+            if (clientPlayerState.isCrawling && clientPlayerState.pounceGroundTime > 0) {
+                long timeSinceGround = System.currentTimeMillis() - clientPlayerState.pounceGroundTime;
+                if (timeSinceGround < ModularMovements.REMOTE_CONFIG.dodge.pounceGroundCooldownMs) {
+                    inPounceCooldown = true;
+                    if (Minecraft.getMinecraft().player.isSprinting()) {
+                        Minecraft.getMinecraft().player.setSprinting(false);
+                    }
+                }
+            }
+            
+            if (Minecraft.getMinecraft().player.isSprinting() && !clientPlayerState.isSitting && !inPounceCooldown) {
                 clientPlayerSitMoveAmplifierCharging += 1.0 / (20.0 * 1.0);
                 clientPlayerSitMoveAmplifierCharging = Math.min(clientPlayerSitMoveAmplifierCharging, 1);
             } else {
@@ -438,6 +451,35 @@ public class ClientListener {
     @SubscribeEvent(priority = EventPriority.LOW, receiveCanceled = false)
     public void onRenderPlayerPre(RenderPlayerEvent.Pre event) {
         isSneaking = event.getEntityPlayer().isSneaking();
+        
+        if (event.getEntityPlayer() == Minecraft.getMinecraft().player) {
+            if (clientPlayerState.isRolling && clientPlayerState.lockedRenderYaw != null) {
+                event.getEntityPlayer().renderYawOffset = clientPlayerState.lockedRenderYaw;
+                event.getEntityPlayer().rotationYawHead = clientPlayerState.lockedRenderYaw;
+            } else if (clientPlayerState.isPouncing) {
+                event.getEntityPlayer().renderYawOffset = interpolateRotation(
+                    event.getEntityPlayer().renderYawOffset, 
+                    event.getEntityPlayer().rotationYaw, 
+                    0.15f
+                );
+            }
+        } else {
+            // 其他玩家
+            if (ohterPlayerStateMap.containsKey(event.getEntityPlayer().getEntityId())) {
+                PlayerState state = ohterPlayerStateMap.get(event.getEntityPlayer().getEntityId());
+                if (state.isRolling && state.lockedRenderYaw != null) {
+                    event.getEntityPlayer().renderYawOffset = state.lockedRenderYaw;
+                    event.getEntityPlayer().rotationYawHead = state.lockedRenderYaw;
+                } else if (state.isRolling || state.isPouncing) {
+                    event.getEntityPlayer().renderYawOffset = interpolateRotation(
+                        event.getEntityPlayer().renderYawOffset, 
+                        event.getEntityPlayer().rotationYaw, 
+                        0.15f
+                    );
+                }
+            }
+        }
+        
         if (!clientPlayerState.isCrawling && !clientPlayerState.isSitting) {
             return;
         }
@@ -593,7 +635,30 @@ public class ClientListener {
     @SubscribeEvent
     public void onInputUpdate(InputUpdateEvent event) {
         EntityPlayer clientPlayer = Minecraft.getMinecraft().player;
-
+        
+        if (clientPlayerState.isCrawling && clientPlayerState.pounceGroundTime > 0) {
+            long timeSinceGround = System.currentTimeMillis() - clientPlayerState.pounceGroundTime;
+            if (timeSinceGround < ModularMovements.REMOTE_CONFIG.dodge.pounceGroundCooldownMs) {
+                
+                event.getMovementInput().moveForward = 0;
+                event.getMovementInput().moveStrafe = 0;
+                event.getMovementInput().jump = false;
+                event.getMovementInput().sneak = false;
+                
+                KeyBindingUtil.disableSprinting(true);
+                
+                if (clientPlayer.isSprinting()) {
+                    clientPlayer.setSprinting(false);
+                }
+                
+                return;
+            } else {
+                KeyBindingUtil.disableSprinting(false);
+            }
+        } else {
+            KeyBindingUtil.disableSprinting(false);
+        }
+ 
         if (clientPlayerState.isSitting) {
             event.getMovementInput().moveForward *= 0.3;
             event.getMovementInput().moveStrafe *= 0.3;
@@ -783,6 +848,50 @@ public class ClientListener {
                 clientPlayerState.disableCrawling();
             }
         }
+        
+        if (clientPlayerState.isPouncing && clientPlayerState.isCrawling) {
+            if (!event.player.onGround) {
+                clientPlayerState.wasInAirDuringPounce = true;
+            }
+            
+            if (event.player.onGround && clientPlayerState.pounceGroundTime == 0 
+                && clientPlayerState.wasInAirDuringPounce) {
+                clientPlayerState.pounceGroundTime = System.currentTimeMillis();
+            }
+        }
+        
+        if (!clientPlayerState.isPouncing) {
+            if (!event.player.onGround && clientPlayerState.pounceGroundTime > 0) {
+                clientPlayerState.pounceGroundTime = 0;
+                clientPlayerState.wasInAirDuringPounce = false;
+            }
+        }
+        
+        if (clientPlayerState.isCrawling && clientPlayerState.pounceGroundTime > 0) {
+            long timeSinceGround = System.currentTimeMillis() - clientPlayerState.pounceGroundTime;
+            if (timeSinceGround < ModularMovements.REMOTE_CONFIG.dodge.pounceGroundCooldownMs) {
+                event.player.motionX = 0;
+                event.player.motionZ = 0;
+                if (event.player.isSprinting()) {
+                    event.player.setSprinting(false);
+                }
+            }
+        }
+        
+        if (!clientPlayerState.isPouncing && clientPlayerState.isCrawling && !event.player.onGround) {
+            long timeSincePouncEnd = System.currentTimeMillis() - clientPlayerState.pounceEndTime;
+            if (timeSincePouncEnd > 100 && timeSincePouncEnd < 10000) { // 10秒内有效
+                double d0 = 0.3;
+                if (!event.player.world.collidesWithAnyBlock(new AxisAlignedBB(
+                    event.player.posX - d0, event.player.posY, event.player.posZ - d0,
+                    event.player.posX + d0, event.player.posY + 1.8, event.player.posZ + d0))) {
+                    clientPlayerState.disableCrawling();
+                    clientPlayerState.isBackLying = false;
+                    clientPlayerState.pounceGroundTime = 0;
+                }
+            }
+        }
+        
         if (event.phase != Phase.END) {
             if (lastAABB != null && event.player.getEntityBoundingBox() == lastModAABB) {
                 event.player.setEntityBoundingBox(lastAABB);
@@ -965,9 +1074,59 @@ public class ClientListener {
     }
 
     /**
-     * 此方法为对Dodge输入的处理
+     * 八方向枚举
      */
+    private enum Direction8 {
+        FORWARD,        // 前
+        FORWARD_LEFT,   // 左前
+        FORWARD_RIGHT,  // 右前
+        LEFT,           // 正左
+        RIGHT,          // 正右
+        BACKWARD,       // 后
+        BACKWARD_LEFT,  // 左后
+        BACKWARD_RIGHT, // 右后
+        NONE            // 无方向
+    }
+    
+    /**
+     * 检测玩家当前的八方向移动方向
+     */
+    private static Direction8 detectDirection8(GameSettings gs) {
+        boolean forward = Keyboard.isKeyDown(gs.keyBindForward.getKeyCode());
+        boolean back = Keyboard.isKeyDown(gs.keyBindBack.getKeyCode());
+        boolean left = Keyboard.isKeyDown(gs.keyBindLeft.getKeyCode());
+        boolean right = Keyboard.isKeyDown(gs.keyBindRight.getKeyCode());
+        
+        // 八方向判断
+        if (forward && left) return Direction8.FORWARD_LEFT;
+        if (forward && right) return Direction8.FORWARD_RIGHT;
+        if (forward) return Direction8.FORWARD;
+        
+        if (back && left) return Direction8.BACKWARD_LEFT;
+        if (back && right) return Direction8.BACKWARD_RIGHT;
+        if (back) return Direction8.BACKWARD;
+        
+        if (left) return Direction8.LEFT;
+        if (right) return Direction8.RIGHT;
+        
+        return Direction8.NONE;
+    }
+    
+    private static float interpolateRotation(float current, float target, float delta) {
+        float difference = target - current;
+        
+        while (difference < -180.0F) {
+            difference += 360.0F;
+        }
+        while (difference >= 180.0F) {
+            difference -= 360.0F;
+        }
+        
+        return current + difference * delta;
+    }
+
     public static void handleDodgeInput() {
+        EntityPlayerSP player=Minecraft.getMinecraft().player;
         if (Minecraft.getMinecraft().player == null) {
             return;
         }
@@ -977,9 +1136,27 @@ public class ClientListener {
         if (clientPlayerState == null) {
             return;
         }
-        boolean gunInHand=(Minecraft.getMinecraft().player.getHeldItemMainhand().getItem() instanceof ItemGun);
+        
         long time = System.currentTimeMillis();
-        EntityPlayerSP player=Minecraft.getMinecraft().player;
+        if (clientPlayerState.isRolling && time > clientPlayerState.rollEndTime) {
+            clientPlayerState.isRolling = false;
+            clientPlayerState.lockedRenderYaw = null;
+        }
+        if (clientPlayerState.isPouncing && time > clientPlayerState.pounceEndTime) {
+            clientPlayerState.isPouncing = false;
+            
+            if (!player.onGround && clientPlayerState.isCrawling) {
+                double d0 = 0.3;
+                if (!player.world.collidesWithAnyBlock(new AxisAlignedBB(
+                    player.posX - d0, player.posY, player.posZ - d0, 
+                    player.posX + d0, player.posY + 1.8, player.posZ + d0))) {
+                    clientPlayerState.disableCrawling();
+                    clientPlayerState.isBackLying = false;
+                }
+            }
+        }
+        
+        boolean gunInHand=(Minecraft.getMinecraft().player.getHeldItemMainhand().getItem() instanceof ItemGun);
         if(time<clientPlayerState.nextDivingTime) {
             clientPlayerState.enableCrawling(clientPlayerState.isBackLying);
         }else {
@@ -998,12 +1175,12 @@ public class ClientListener {
             return;
         }
         if(clientPlayerState.nextDivingTime==Long.MAX_VALUE) {
-            clientPlayerState.nextDivingTime=time+800;
+            clientPlayerState.nextDivingTime=time+ModularMovements.REMOTE_CONFIG.dodge.pounceCooldownMs;
         }
         if(!clientPlayerState.isStanding()) {
             return;
         }
-        final int DIVING_THRESHOLD=210;
+        final int DIVING_THRESHOLD=ModularMovements.REMOTE_CONFIG.dodge.divingThresholdMs;
         final int ROLL_THRESHOLD=500;
         boolean press = Keyboard.isKeyDown(dodge.getKeyCode());
         if (!holdingDodge && press) {
@@ -1011,73 +1188,175 @@ public class ClientListener {
         }
         if(press) {
             if(time - lastDodgePressTime>=DIVING_THRESHOLD) {
-                //飞扑
+                //飞扑（八方向优化）
+                if (clientPlayerState.rollTick > 0) {
+                    return;
+                }
                 if(clientPlayerState.nextDivingTime<=time) {
                     clientPlayerState.nextDivingTime=Long.MAX_VALUE;
                     float yaw = player.rotationYaw;
                     float f = MathHelper.cos(-yaw * 0.017453292F - (float)Math.PI);
                     float f1 = MathHelper.sin(-yaw * 0.017453292F - (float)Math.PI);
-                    Vec3d vec = new Vec3d(-f1, 0, -f);
-                    boolean back=false;
-                    GameSettings gs=Minecraft.getMinecraft().gameSettings;
-                    if (Keyboard.isKeyDown(gs.keyBindBack.getKeyCode())) {
-                        vec = new Vec3d(-vec.x, 0, -vec.z);
-                        back = true;
-                        AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce_back":"pounce_back"), 1);   
-                    } else if (Keyboard.isKeyDown(gs.keyBindLeft.getKeyCode())) {
-                        vec = new Vec3d(vec.z, 0, -vec.x);
-                        AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce_left":"pounce_left"), 1);   
-                    } else if (Keyboard.isKeyDown(gs.keyBindRight.getKeyCode())) {
-                        vec = new Vec3d(-vec.z, 0, vec.x);
-                        AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce_right":"pounce_right"), 1);   
-                    } else {
-                        AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce":"pounce"), 1);   
+                    Vec3d vec = new Vec3d(-f1, 0, -f); // 基础前方向量
+                    boolean back = false;
+                    GameSettings gs = Minecraft.getMinecraft().gameSettings;
+                    Direction8 dir = detectDirection8(gs);
+                    
+                    switch(dir) {
+                        case FORWARD_LEFT:
+                        case FORWARD:
+                        case FORWARD_RIGHT:
+                            if (dir == Direction8.FORWARD_LEFT) {
+                                vec = new Vec3d(-f1 - f * 0.5, 0, -f + f1 * 0.5).normalize();
+                            } else if (dir == Direction8.FORWARD_RIGHT) {
+                                vec = new Vec3d(-f1 + f * 0.5, 0, -f - f1 * 0.5).normalize();
+                            }
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce":"pounce"), 1);
+                            break;
+                            
+                        case LEFT:
+                            vec = new Vec3d(-f, 0, f1);
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce_left":"pounce_left"), 1);
+                            break;
+                            
+                        case RIGHT:
+                            vec = new Vec3d(f, 0, -f1);
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce_right":"pounce_right"), 1);
+                            break;
+                            
+                        case BACKWARD_LEFT:
+                        case BACKWARD:
+                        case BACKWARD_RIGHT:
+                            back = true;
+                            if (dir == Direction8.BACKWARD_LEFT) {
+                                vec = new Vec3d(f1 - f * 0.5, 0, f + f1 * 0.5).normalize();
+                            } else if (dir == Direction8.BACKWARD_RIGHT) {
+                                vec = new Vec3d(f1 + f * 0.5, 0, f - f1 * 0.5).normalize();
+                            } else {
+                                vec = new Vec3d(f1, 0, f);
+                            }
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce_back":"pounce_back"), 1);
+                            break;
+                            
+                        case NONE:
+                        default:
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_pounce":"pounce"), 1);
+                            break;
                     }
-                    vec=vec.normalize().scale(0.8);
-                    player.motionX=vec.x;
-                    player.motionY=0.45;
-                    player.motionZ=vec.z;
+                    
+                    vec = vec.normalize().scale(0.8);
+                    player.motionX = vec.x;
+                    player.motionY = 0.45;
+                    player.motionZ = vec.z;
                     clientPlayerState.enableCrawling(back);
+                    
+                    clientPlayerState.pounceGroundTime = 0;
+                    clientPlayerState.wasInAirDuringPounce = false;
+                    
+                    clientPlayerState.isPouncing = true;
+                    clientPlayerState.pounceEndTime = time + 1000;
                 }
             }
         }
         if (holdingDodge && !press) {
-            //翻滚
+            //翻滚（八方向优化）
+            if (clientPlayerState.isPouncing) {
+                return;
+            }
             if (time - lastDodgePressTime < DIVING_THRESHOLD) {
                 if(clientPlayerState.nextStepTime<=time) {
                     if(clientPlayerState.nextStepTime+500<=time) {
-                        clientPlayerState.nextStepTime=time+200;   
+                        clientPlayerState.nextStepTime=time+ModularMovements.REMOTE_CONFIG.dodge.rollCooldownMs;   
                     }else {
-                        clientPlayerState.nextStepTime=time+2200;
+                        clientPlayerState.nextStepTime=time+ModularMovements.REMOTE_CONFIG.dodge.rollSecondCooldownMs;
                     }
                     float yaw = player.rotationYaw;
                     float f = MathHelper.cos(-yaw * 0.017453292F - (float)Math.PI);
                     float f1 = MathHelper.sin(-yaw * 0.017453292F - (float)Math.PI);
-                    boolean flag=false;
                     Vec3d vec = new Vec3d(-f1, 0, -f);
-                    GameSettings gs=Minecraft.getMinecraft().gameSettings;
-                    if(Keyboard.isKeyDown(gs.keyBindBack.getKeyCode())) {
-                        vec=new Vec3d(-vec.x, 0, -vec.z);
-                        flag=true;
-                    }
-                    if(Keyboard.isKeyDown(gs.keyBindLeft.getKeyCode())) {
-                        vec=new Vec3d(vec.z, 0, -vec.x);
-                    }
-                    if(Keyboard.isKeyDown(gs.keyBindRight.getKeyCode())) {
-                        vec=new Vec3d(-vec.z, 0, vec.x);
-                    }
-                    if(!flag) {                    
-                        vec=vec.normalize().scale(0.3);
-                        clientPlayerState.rollVec=vec;
-                        clientPlayerState.rollTick=20;
-                        player.motionX=vec.x;
-                        player.motionZ=vec.z;
-                        AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_roll":"roll"), 1);   
-                    }else {
-                        vec=vec.normalize().scale(0.5);
-                        clientPlayerState.rollVec=vec;
-                        player.motionX=vec.x;
-                        player.motionZ=vec.z; 
+                    GameSettings gs = Minecraft.getMinecraft().gameSettings;
+                    Direction8 dir = detectDirection8(gs);
+                    boolean isBackward = false;
+                    
+                    switch(dir) {
+                        case FORWARD_LEFT:
+                        case FORWARD:
+                        case FORWARD_RIGHT:
+                            if (dir == Direction8.FORWARD_LEFT) {
+                                vec = new Vec3d(-f1 - f * 0.5, 0, -f + f1 * 0.5).normalize();
+                            } else if (dir == Direction8.FORWARD_RIGHT) {
+                                vec = new Vec3d(-f1 + f * 0.5, 0, -f - f1 * 0.5).normalize();
+                            }
+                            vec = vec.normalize().scale(0.3);
+                            clientPlayerState.rollVec = vec;
+                            clientPlayerState.rollTick = 20;
+                            player.motionX = vec.x;
+                            player.motionZ = vec.z;
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_roll":"roll"), 1);
+                            
+                            clientPlayerState.isRolling = true;
+                            clientPlayerState.rollEndTime = time + 1000;
+                            clientPlayerState.lockedRenderYaw = player.rotationYaw;
+                            break;
+                            
+                        case LEFT:
+                            vec = new Vec3d(-f, 0, f1);
+                            vec = vec.normalize().scale(0.3);
+                            clientPlayerState.rollVec = vec;
+                            clientPlayerState.rollTick = 20;
+                            player.motionX = vec.x;
+                            player.motionZ = vec.z;
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_roll":"roll"), 1);
+                            
+                            clientPlayerState.isRolling = true;
+                            clientPlayerState.rollEndTime = time + 1000;
+                            clientPlayerState.lockedRenderYaw = player.rotationYaw - 90.0f;
+                            break;
+                            
+                        case RIGHT:
+                            vec = new Vec3d(f, 0, -f1);
+                            vec = vec.normalize().scale(0.3);
+                            clientPlayerState.rollVec = vec;
+                            clientPlayerState.rollTick = 20;
+                            player.motionX = vec.x;
+                            player.motionZ = vec.z;
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_roll":"roll"), 1);
+                            
+                            clientPlayerState.isRolling = true;
+                            clientPlayerState.rollEndTime = time + 1000;
+                            clientPlayerState.lockedRenderYaw = player.rotationYaw + 90.0f;
+                            break;
+                            
+                        case BACKWARD_LEFT:
+                        case BACKWARD:
+                        case BACKWARD_RIGHT:
+                            isBackward = true;
+                            if (dir == Direction8.BACKWARD_LEFT) {
+                                vec = new Vec3d(f1 - f * 0.5, 0, f + f1 * 0.5).normalize();
+                            } else if (dir == Direction8.BACKWARD_RIGHT) {
+                                vec = new Vec3d(f1 + f * 0.5, 0, f - f1 * 0.5).normalize();
+                            } else {
+                                vec = new Vec3d(f1, 0, f);
+                            }
+                            vec = vec.normalize().scale(0.5);
+                            clientPlayerState.rollVec = vec;
+                            player.motionX = vec.x;
+                            player.motionZ = vec.z;
+                            break;
+                            
+                        case NONE:
+                        default:
+                            vec = vec.normalize().scale(0.3);
+                            clientPlayerState.rollVec = vec;
+                            clientPlayerState.rollTick = 20;
+                            player.motionX = vec.x;
+                            player.motionZ = vec.z;
+                            AnimationHandler.sendAnimation(player.getUniqueID(), (gunInHand ? "gun_roll":"roll"), 1);
+                            
+                            clientPlayerState.isRolling = true;
+                            clientPlayerState.rollEndTime = time + 1000;
+                            clientPlayerState.lockedRenderYaw = player.rotationYaw;
+                            break;
                     }
                 }
             }
@@ -1088,9 +1367,35 @@ public class ClientListener {
     
     public static void handleRoll() {
         if(clientPlayerState.rollTick>0) {
+            // 翻滚期间：强制使用固定的移动向量，完全不受视角影响
             Minecraft.getMinecraft().player.motionX=clientPlayerState.rollVec.x;
             Minecraft.getMinecraft().player.motionZ=clientPlayerState.rollVec.z;
             clientPlayerState.rollTick--;
+            
+            clientPlayerState.prevRollProgress = clientPlayerState.rollProgress;
+            
+            if (clientPlayerState.rollTick > 10) {
+                clientPlayerState.rollProgress = (20 - clientPlayerState.rollTick) / 10.0f;
+            } else {
+                clientPlayerState.rollProgress = clientPlayerState.rollTick / 10.0f;
+            }
+        } else {
+            // 翻滚结束：清除锁定，恢复正常
+            clientPlayerState.prevRollProgress = clientPlayerState.rollProgress;
+            clientPlayerState.rollProgress = 0.0f;
+            if (clientPlayerState.lockedRenderYaw != null && !clientPlayerState.isRolling) {
+                clientPlayerState.lockedRenderYaw = null;
+            }
         }
+    }
+    
+    /**
+     * 获取插值后的翻滚进度（用于渲染）
+     * @param partialTick 渲染的部分tick（0.0-1.0）
+     * @return 插值后的进度
+     */
+    public static float getRollProgressInterpolated(float partialTick) {
+        return clientPlayerState.prevRollProgress + 
+               (clientPlayerState.rollProgress - clientPlayerState.prevRollProgress) * partialTick;
     }
 }

--- a/src/main/java/mchhui/modularmovements/tactical/network/TacticalHandler.java
+++ b/src/main/java/mchhui/modularmovements/tactical/network/TacticalHandler.java
@@ -41,18 +41,50 @@ public class TacticalHandler {
                 break;
 
             case MOD_CONFIG:
+                // Lean 配置
                 boolean leanEnable = buffer.readBoolean();
-                boolean sitEnable = buffer.readBoolean();
-                boolean slideEnable = buffer.readBoolean();
-                boolean crawlEnable = buffer.readBoolean();
                 boolean withGunsOnly = buffer.readBoolean();
+                
+                // Sit 配置
+                boolean sitEnable = buffer.readBoolean();
+                int sitCooldownMs = buffer.readInt();
+                
+                // Slide 配置
+                boolean slideEnable = buffer.readBoolean();
                 float slideMaxForce = buffer.readFloat();
+                
+                // Crawl 配置
+                boolean crawlEnable = buffer.readBoolean();
+                int crawlCooldownMs = buffer.readInt();
+                
+                // Dodge 配置
+                boolean dodgeEnable = buffer.readBoolean();
+                int divingThresholdMs = buffer.readInt();
+                int pounceCooldownMs = buffer.readInt();
+                int pounceGroundCooldownMs = buffer.readInt();
+                int rollCooldownMs = buffer.readInt();
+                int rollSecondCooldownMs = buffer.readInt();
 
+                // 应用配置
                 ModularMovements.REMOTE_CONFIG.lean.enable = leanEnable;
+                ModularMovements.REMOTE_CONFIG.lean.withGunsOnly = withGunsOnly;
+                
                 ModularMovements.REMOTE_CONFIG.sit.enable = sitEnable;
+                ModularMovements.REMOTE_CONFIG.sit.cooldownMs = sitCooldownMs;
+                
                 ModularMovements.REMOTE_CONFIG.slide.enable = slideEnable;
-                ModularMovements.REMOTE_CONFIG.crawl.enable = crawlEnable;
                 ModularMovements.REMOTE_CONFIG.slide.maxForce = slideMaxForce;
+                
+                ModularMovements.REMOTE_CONFIG.crawl.enable = crawlEnable;
+                ModularMovements.REMOTE_CONFIG.crawl.cooldownMs = crawlCooldownMs;
+                
+                ModularMovements.REMOTE_CONFIG.dodge.enable = dodgeEnable;
+                ModularMovements.REMOTE_CONFIG.dodge.divingThresholdMs = divingThresholdMs;
+                ModularMovements.REMOTE_CONFIG.dodge.pounceCooldownMs = pounceCooldownMs;
+                ModularMovements.REMOTE_CONFIG.dodge.pounceGroundCooldownMs = pounceGroundCooldownMs;
+                ModularMovements.REMOTE_CONFIG.dodge.rollCooldownMs = rollCooldownMs;
+                ModularMovements.REMOTE_CONFIG.dodge.rollSecondCooldownMs = rollSecondCooldownMs;
+                
                 break;
         }
     }
@@ -132,15 +164,32 @@ public class TacticalHandler {
         buffer.writeEnumValue(EnumFeatures.Tactical);
         buffer.writeEnumValue(EnumPacketType.MOD_CONFIG);
         
+        // Lean 配置
         buffer.writeBoolean(ModularMovements.CONFIG.lean.enable);
-        buffer.writeBoolean(ModularMovements.CONFIG.sit.enable);
-        buffer.writeBoolean(ModularMovements.CONFIG.slide.enable);
-        buffer.writeBoolean(ModularMovements.CONFIG.crawl.enable);
-        
         buffer.writeBoolean(ModularMovements.CONFIG.lean.withGunsOnly);
+        
+        // Sit 配置
+        buffer.writeBoolean(ModularMovements.CONFIG.sit.enable);
+        buffer.writeInt(ModularMovements.CONFIG.sit.cooldownMs);
+        
+        // Slide 配置
+        buffer.writeBoolean(ModularMovements.CONFIG.slide.enable);
         buffer.writeFloat(ModularMovements.CONFIG.slide.maxForce);
         
+        // Crawl 配置
+        buffer.writeBoolean(ModularMovements.CONFIG.crawl.enable);
+        buffer.writeInt(ModularMovements.CONFIG.crawl.cooldownMs);
+        
+        // Dodge 配置（新增）
+        buffer.writeBoolean(ModularMovements.CONFIG.dodge.enable);
+        buffer.writeInt(ModularMovements.CONFIG.dodge.divingThresholdMs);
+        buffer.writeInt(ModularMovements.CONFIG.dodge.pounceCooldownMs);
+        buffer.writeInt(ModularMovements.CONFIG.dodge.pounceGroundCooldownMs);
+        buffer.writeInt(ModularMovements.CONFIG.dodge.rollCooldownMs);
+        buffer.writeInt(ModularMovements.CONFIG.dodge.rollSecondCooldownMs);
+        
         ModularMovements.channel.sendTo(new FMLProxyPacket(buffer, "modularmovements"), entityPlayer);
+        
     }
 
     public enum EnumPacketType {

--- a/src/main/java/mchhui/modularmovements/tactical/server/ServerListener.java
+++ b/src/main/java/mchhui/modularmovements/tactical/server/ServerListener.java
@@ -70,6 +70,20 @@ public class ServerListener {
         }
         return playerStateMap.get(id).isCrawling;
     }
+    
+    public static boolean isRolling(Integer id) {
+        if (!playerStateMap.containsKey(id)) {
+            return false;
+        }
+        return playerStateMap.get(id).isRolling;
+    }
+    
+    public static boolean isPouncing(Integer id) {
+        if (!playerStateMap.containsKey(id)) {
+            return false;
+        }
+        return playerStateMap.get(id).isPouncing;
+    }
 
     public static void updateOffset(Integer id) {
         if (!playerStateMap.containsKey(id)) {


### PR DESCRIPTION
1、四方改八方
2、无方向按alt键默认方向朝前
3、roll取消移动音效(动态环绕兼用需等待)
4、飞扑之后如果浮空取消趴下状态
5、roll的时候阻止开火，锁定模型朝向为翻滚方向
6、飞扑之后需要一段时间才能起来（大概0.5s），而且需要播放完起身动画(暂无)
7、飞扑后摇阻止疾跑，使用内置方法
8、玩家翻滚时阻止其他动作
9、趴下、飞扑、翻滚增加冷却时间配置
10、翻滚时阻断玩家视角对移动向量的影响